### PR TITLE
Version 1.0.0

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,256 +1,37 @@
 import bpy
 import time
+from .utils.registration import *
+
+
+# Check if addon is being reloaded
+# This also allows script.reload() to reload the addon
+if "operator_sync_view" not in locals():
+    from . import sync_handler, ui, operator_sync_view
+else:
+    import importlib
+    sync_handler = importlib.reload(sync_handler)
+    ui = importlib.reload(ui)
+    operator_sync_view = importlib.reload(operator_sync_view)
+
+modules = [ui, operator_sync_view]
+
 bl_info = {
     "name": "Viewport Sync",
     "author": "Bowen Wu",
     "description": "Test",
     "blender": (2, 80, 3),
-    "version": (4, 2, 0),
-    "location": "",
+    "version": (0, 1, 0),
+    "location": "View3D > Header Bar",
     "warning": "",
-    "category": ""
+    "category": "3D View"
 }
 
-'''
-import bpy
-import gpu
-from gpu_extras.presets import draw_texture_2d
 
-WIDTH = 512
-HEIGHT = 256
-
-offscreen = gpu.types.GPUOffScreen(WIDTH, HEIGHT)
-
-
-def draw():
-    context = bpy.context
-    scene = context.scene
-
-    view_matrix = scene.camera.matrix_world.inverted()
-    view3d = bpy.context.space_data
-    
-    
-    view_matrix = view3d.region_3d.view_matrix
-    perspective_matrix = view3d.region_3d.window_matrix.normalized()
-    
-    offscreen.draw_view3d(
-        scene,
-        context.view_layer,
-        context.space_data,
-        context.region,
-        view_matrix,
-        perspective_matrix,
-        do_color_management=True)
-
-    gpu.state.depth_mask_set(False)
-    draw_texture_2d(offscreen.texture_color, (10, 10), WIDTH, HEIGHT)
-
-
-bpy.types.SpaceView3D.draw_handler_add(draw, (), 'WINDOW', 'POST_PIXEL')
-'''
-
-
-def update_space(source_space, target_space):
-    def update_attributes(source, target, attributes):
-        for attribute in attributes:
-            new_attribute = getattr(source, attribute, None)
-            if new_attribute is not None:
-                setattr(target, attribute, new_attribute)
-
-    # Update space attributes, causes 2 additional redraws on target
-    space_attributes = ['clip_end', 'clip_start', 'lens']
-    update_attributes(source_space, target_space, space_attributes)
-    # Update ViewRegion3D attributes
-    # All modifiable attributes, causes 8 additional redraws on target
-    view_region_3d_attributes = ['clip_planes', 'is_orthographic_side_view', 'is_perspective', 'lock_rotation', 'show_sync_view', 'use_box_clip', 'use_clip_planes',
-                                 'view_camera_offset', 'view_camera_zoom', 'view_distance', 'view_location', 'view_perspective', 'view_rotation']
-    # view_region_3d_attributes = ['view_matrix', 'view_camera_zoom',]
-    update_attributes(source_space.region_3d, target_space.region_3d, view_region_3d_attributes)
-
-
-def sync_views(context: bpy.types.Context, event, is_zoom=False):
-    def is_out_of_area(area_xy, mouse_xy):
-        return mouse_xy[0] < 0 or mouse_xy[0] > area_xy[0] or mouse_xy[1] < 0 or mouse_xy[1] > area_xy[0]
-    time_start = time.time()
-    context_area = context.area
-    if context_area is None:
-        print("context.area is none, returning with context" + str(context))
-        return
-    main_view_space = context.space_data
-
-    # Handle zoom
-    if is_zoom:
-        print("Before", main_view_space.region_3d.view_distance)
-        bpy.ops.view3d.zoom(delta=1 if event.type == 'WHEELUPMOUSE' else -1)
-        main_view_space.region_3d.update()  # Force the value to be updated
-        print("After", main_view_space.region_3d.view_distance)
-
-    # Check if we're actually orbiting a viewport that's not from the original context and update the view space object
-    if (is_out_of_area((context_area.width, context_area.height), (event.mouse_region_x, event.mouse_region_y))):
-        print("Out of bounds!")
-        for area in context.screen.areas:
-            new_mouse_area_loc = (event.mouse_x - area.x,
-                                  event.mouse_y - area.y)
-            if area.ui_type == "VIEW_3D" and not is_out_of_area((area.width, area.height), new_mouse_area_loc):
-                print("Main view region updated!")
-                area.spaces[0].region_3d.view_distance = main_view_space.region_3d.view_distance
-                main_view_space = area.spaces[0]
-                main_view_space.region_3d.update()  # Force the value to be updated for zoom
-                break
-    # print(main_view_space.region_3d.view_distance, main_view_space.region_3d.view_location, main_view_space.region_3d.view_matrix)
-
-    # Now update all 3d viewport spaces
-    for area in context.screen.areas:
-        # print(area.ui_type)
-        if area.ui_type == "VIEW_3D":
-            update_space(main_view_space, area.spaces[0])
-    print("Viewport Sync Finished: %.4f sec" % (time.time() - time_start))
-
-
-class SyncDraw:
-    def __init__(self):
-        self.add_handler()
-        self.areas_to_sync = set()
-        self.source_area = None
-        self.redraw_counter = dict()
-
-    # Handler order: PRE_VIEW, POST_VIEW, POST_PIXEL
-    def add_handler(self):
-        self.handlers = []
-        self.handlers.append(bpy.types.SpaceView3D.draw_handler_add(
-            self.sync_draw_callback, (), 'WINDOW', 'PRE_VIEW'))
-
-    def has_handlers(self):
-        return len(self.handlers) > 0
-
-    def sync_draw_callback(self):
-        context = bpy.context
-        print("Callback on area:", context.area)
-
-        this_area = context.area
-        # print("Areas to sync", self.areas_to_sync)
-        # print("Source area: ", self.source_area)
-        # self.areas_to_sync = set()
-        if this_area in self.redraw_counter:
-            # if self.redraw_counter[this_area] > 0:
-            #     self.redraw_counter[this_area] = self.redraw_counter[this_area] - 1
-            #     print("early return, decrementing entry")
-            #     return
-            # else:
-            self.redraw_counter.pop(this_area)
-            print("Early return, removing entry")
-            return
-
-        if this_area in self.areas_to_sync:
-            print("This area is marked for sync", this_area)
-            update_space(self.source_area.spaces[0], this_area.spaces[0])
-            self.areas_to_sync.remove(this_area)
-            self.redraw_counter[this_area] = 0  # update_space causes 10 additional redraws, ignore those in here
-            self.redraw_counter[self.source_area] = 0  # There will be one additional redraw for our source area
-            # print("Area synced")
-            return
-        # elif this_area == self.source_area:
-        #     print("Found self area, cleaing target area")
-        #     self.source_area = None
-        #     self.areas_to_sync = set()
-        #     return
-        # if self.areas_to_sync:
-        #     print("Propagated drawcallsync on area", context.area)
-        #     # self.remove_handler()
-        #     return
-        # print(" this area", source_area)
-        # if self.source_area is not None:
-        #     return
-        source_area = context.area
-        self.source_area = source_area
-        print("New source area", source_area)
-        for area in context.screen.areas:
-            if area.type == "VIEW_3D" and area != source_area:
-                # print("Other area:", area)
-                self.areas_to_sync.add(area)
-                area.tag_redraw()
-
-        # print(self.areas_to_sync)
-        # print("Update finished")
-
-    def remove_handler(self):
-        for handler in self.handlers:
-            bpy.types.SpaceView3D.draw_handler_remove(handler, 'WINDOW')
-        self.handlers = []
-
-
-class SyncviewModal(bpy.types.Operator):
-    """Tooltip"""
-    bl_idname = "syncview.syncview_modal"
-    bl_label = "Sync View Modal Operator"
-
-    _syncing = False
-    handler = None
-
-    # def execute(self, context):
-
-    #     sync_views(context)
-    #     return {'FINISHED'}
-
-    def invoke(self, context: bpy.types.Context, event: bpy.types.Event):
-        if 'view_sync' not in bpy.app.driver_namespace:
-            print("Adding handle")
-            bpy.app.driver_namespace['view_sync'] = SyncDraw()
-            return {'FINISHED'}
-
-        if bpy.app.driver_namespace['view_sync'].has_handlers():
-            print("Removing handle")
-            bpy.app.driver_namespace['view_sync'].remove_handler()
-            del bpy.app.driver_namespace['view_sync']
-
-        return {'FINISHED'}
-
-    # def modal(self, context, event):
-    #     view3d = bpy.context.space_data
-
-    #     print(view3d.render_border_min_x, view3d.render_border_max_x)
-
-    #     for area in context.screen.areas:
-    #         if area.type == "VIEW_3D":
-    #             print(str(area) + " ", end="")
-    #     print()
-    #     if context.area is None:
-    #         return {"FINISHED"}
-    #     # TODO: Fix alt + middle mouse axis views
-    #     if event.type == 'MIDDLEMOUSE' and event.value == 'PRESS' and not event.alt:
-    #         self._syncing = True
-    #         print("Syncing")
-    #         return {'PASS_THROUGH'}
-    #     elif event.type == 'MOUSEMOVE' and self._syncing:
-    #         sync_views(context, event)
-    #         self._syncing = False
-    #         return {'PASS_THROUGH'}
-    #     elif event.type in {'WHEELUPMOUSE', 'WHEELDOWNMOUSE'} and not (event.alt or event.ctrl or event.shift or event.oskey):
-    #         # Since the zoom operator takes place after this, it will be delayed by one operation if we do not just handle zoom right here
-    #         sync_views(context, event, True)
-    #         return {'RUNNING_MODAL'}  # Consume the event and prevent regular zoom from occuring
-    #     elif event.type == "RIGHTMOUSE":
-    #         return {"FINISHED"}
-    #     return {'PASS_THROUGH'}
-
-
-def menu_func(self, context):
-    self.layout.operator(SyncviewModal.bl_idname, text=SyncviewModal.bl_label)
-
-
-# Register and add to the "object" menu (required to also use F3 search "Simple Object Operator" for quick access).
 def register():
-    bpy.utils.register_class(SyncviewModal)
-    bpy.types.VIEW3D_MT_object.append(menu_func)
+    for module in modules:
+        module.register()
 
 
 def unregister():
-    bpy.utils.unregister_class(SyncviewModal)
-    bpy.types.VIEW3D_MT_object.remove(menu_func)
-
-
-if __name__ == "__main__":
-    register()
-
-    # test call
-    bpy.ops.object.simple_operator()
+    for module in modules[::-1]:
+        module.unregister()

--- a/__init__.py
+++ b/__init__.py
@@ -15,7 +15,7 @@ else:
     msgbus = importlib.reload(msgbus)
     preferences = importlib.reload(preferences)
 
-modules = [operator_sync_view, msgbus, ui, preferences]
+modules = [preferences, operator_sync_view, msgbus, ui]
 
 bl_info = {
     "name": "Viewport Sync",

--- a/__init__.py
+++ b/__init__.py
@@ -11,39 +11,80 @@ bl_info = {
     "category": ""
 }
 
+'''
+import bpy
+import gpu
+from gpu_extras.presets import draw_texture_2d
 
-def sync_views(context, event, is_zoom=False):
+WIDTH = 512
+HEIGHT = 256
+
+offscreen = gpu.types.GPUOffScreen(WIDTH, HEIGHT)
+
+
+def draw():
+    context = bpy.context
+    scene = context.scene
+
+    view_matrix = scene.camera.matrix_world.inverted()
+    view3d = bpy.context.space_data
+    
+    
+    view_matrix = view3d.region_3d.view_matrix
+    perspective_matrix = view3d.region_3d.window_matrix.normalized()
+    
+    offscreen.draw_view3d(
+        scene,
+        context.view_layer,
+        context.space_data,
+        context.region,
+        view_matrix,
+        perspective_matrix,
+        do_color_management=True)
+
+    gpu.state.depth_mask_set(False)
+    draw_texture_2d(offscreen.texture_color, (10, 10), WIDTH, HEIGHT)
+
+
+bpy.types.SpaceView3D.draw_handler_add(draw, (), 'WINDOW', 'POST_PIXEL')
+'''
+
+
+def update_space(source_space, target_space):
+    def update_attributes(source, target, attributes):
+        for attribute in attributes:
+            new_attribute = getattr(source, attribute, None)
+            if new_attribute is not None:
+                setattr(target, attribute, new_attribute)
+
+    # Update space attributes, causes 2 additional redraws on target
+    space_attributes = ['clip_end', 'clip_start', 'lens']
+    update_attributes(source_space, target_space, space_attributes)
+    # Update ViewRegion3D attributes
+    # All modifiable attributes, causes 8 additional redraws on target
+    view_region_3d_attributes = ['clip_planes', 'is_orthographic_side_view', 'is_perspective', 'lock_rotation', 'show_sync_view', 'use_box_clip', 'use_clip_planes',
+                                 'view_camera_offset', 'view_camera_zoom', 'view_distance', 'view_location', 'view_perspective', 'view_rotation']
+    # view_region_3d_attributes = ['view_matrix', 'view_camera_zoom',]
+    update_attributes(source_space.region_3d, target_space.region_3d, view_region_3d_attributes)
+
+
+def sync_views(context: bpy.types.Context, event, is_zoom=False):
     def is_out_of_area(area_xy, mouse_xy):
         return mouse_xy[0] < 0 or mouse_xy[0] > area_xy[0] or mouse_xy[1] < 0 or mouse_xy[1] > area_xy[0]
     time_start = time.time()
     context_area = context.area
+    if context_area is None:
+        print("context.area is none, returning with context" + str(context))
+        return
     main_view_space = context.space_data
-    
-    def update_space(source_space, target_space):
-        def update_attributes(source, target, attributes):
-            for attribute in attributes:
-                new_attribute = getattr(source, attribute, None)
-                if new_attribute is not None:
-                    setattr(target, attribute, new_attribute)
-
-        # Update space attributes
-        space_attributes = ['clip_end', 'clip_start', 'lens']
-        update_attributes(source_space,
-                    target_space, space_attributes)
-        # Update ViewRegion3D attributes
-        # All modifiable attributes
-        view_region_3d_attributes = ['clip_planes', 'is_orthographic_side_view', 'is_perspective', 'lock_rotation', 'show_sync_view', 'use_box_clip', 'use_clip_planes',
-                                     'view_camera_offset', 'view_camera_zoom', 'view_distance', 'view_location', 'view_perspective', 'view_rotation']
-        update_attributes(source_space.region_3d,
-                          target_space.region_3d, view_region_3d_attributes)
 
     # Handle zoom
     if is_zoom:
         print("Before", main_view_space.region_3d.view_distance)
         bpy.ops.view3d.zoom(delta=1 if event.type == 'WHEELUPMOUSE' else -1)
-        main_view_space.region_3d.update() # Force the value to be updated
+        main_view_space.region_3d.update()  # Force the value to be updated
         print("After", main_view_space.region_3d.view_distance)
-    
+
     # Check if we're actually orbiting a viewport that's not from the original context and update the view space object
     if (is_out_of_area((context_area.width, context_area.height), (event.mouse_region_x, event.mouse_region_y))):
         print("Out of bounds!")
@@ -54,7 +95,7 @@ def sync_views(context, event, is_zoom=False):
                 print("Main view region updated!")
                 area.spaces[0].region_3d.view_distance = main_view_space.region_3d.view_distance
                 main_view_space = area.spaces[0]
-                main_view_space.region_3d.update() # Force the value to be updated for zoom
+                main_view_space.region_3d.update()  # Force the value to be updated for zoom
                 break
     # print(main_view_space.region_3d.view_distance, main_view_space.region_3d.view_location, main_view_space.region_3d.view_matrix)
 
@@ -66,54 +107,145 @@ def sync_views(context, event, is_zoom=False):
     print("Viewport Sync Finished: %.4f sec" % (time.time() - time_start))
 
 
-class TestOperator(bpy.types.Operator):
+class SyncDraw:
+    def __init__(self):
+        self.add_handler()
+        self.areas_to_sync = set()
+        self.source_area = None
+        self.redraw_counter = dict()
+
+    # Handler order: PRE_VIEW, POST_VIEW, POST_PIXEL
+    def add_handler(self):
+        self.handlers = []
+        self.handlers.append(bpy.types.SpaceView3D.draw_handler_add(
+            self.sync_draw_callback, (), 'WINDOW', 'PRE_VIEW'))
+
+    def has_handlers(self):
+        return len(self.handlers) > 0
+
+    def sync_draw_callback(self):
+        context = bpy.context
+        print("Callback on area:", context.area)
+
+        this_area = context.area
+        # print("Areas to sync", self.areas_to_sync)
+        # print("Source area: ", self.source_area)
+        # self.areas_to_sync = set()
+        if this_area in self.redraw_counter:
+            # if self.redraw_counter[this_area] > 0:
+            #     self.redraw_counter[this_area] = self.redraw_counter[this_area] - 1
+            #     print("early return, decrementing entry")
+            #     return
+            # else:
+            self.redraw_counter.pop(this_area)
+            print("Early return, removing entry")
+            return
+
+        if this_area in self.areas_to_sync:
+            print("This area is marked for sync", this_area)
+            update_space(self.source_area.spaces[0], this_area.spaces[0])
+            self.areas_to_sync.remove(this_area)
+            self.redraw_counter[this_area] = 0  # update_space causes 10 additional redraws, ignore those in here
+            self.redraw_counter[self.source_area] = 0  # There will be one additional redraw for our source area
+            # print("Area synced")
+            return
+        # elif this_area == self.source_area:
+        #     print("Found self area, cleaing target area")
+        #     self.source_area = None
+        #     self.areas_to_sync = set()
+        #     return
+        # if self.areas_to_sync:
+        #     print("Propagated drawcallsync on area", context.area)
+        #     # self.remove_handler()
+        #     return
+        # print(" this area", source_area)
+        # if self.source_area is not None:
+        #     return
+        source_area = context.area
+        self.source_area = source_area
+        print("New source area", source_area)
+        for area in context.screen.areas:
+            if area.type == "VIEW_3D" and area != source_area:
+                # print("Other area:", area)
+                self.areas_to_sync.add(area)
+                area.tag_redraw()
+
+        # print(self.areas_to_sync)
+        # print("Update finished")
+
+    def remove_handler(self):
+        for handler in self.handlers:
+            bpy.types.SpaceView3D.draw_handler_remove(handler, 'WINDOW')
+        self.handlers = []
+
+
+class SyncviewModal(bpy.types.Operator):
     """Tooltip"""
-    bl_idname = "test.test_modal"
-    bl_label = "Test Modal Operator"
+    bl_idname = "syncview.syncview_modal"
+    bl_label = "Sync View Modal Operator"
 
     _syncing = False
+    handler = None
 
     # def execute(self, context):
 
     #     sync_views(context)
     #     return {'FINISHED'}
 
-    def invoke(self, context, event):
-        context.window_manager.modal_handler_add(self)
-        return {'RUNNING_MODAL'}
+    def invoke(self, context: bpy.types.Context, event: bpy.types.Event):
+        if 'view_sync' not in bpy.app.driver_namespace:
+            print("Adding handle")
+            bpy.app.driver_namespace['view_sync'] = SyncDraw()
+            return {'FINISHED'}
 
-    def modal(self, context, event):
-        print(event.type, event.value)
-        # TODO: Fix alt + middle mouse axis views
-        if event.type == 'MIDDLEMOUSE' and event.value == 'PRESS' and not event.alt:
-            self._syncing = True
-            print("Syncing")
-            return {'PASS_THROUGH'}
-        elif event.type == 'MOUSEMOVE' and self._syncing:
-            sync_views(context, event)
-            self._syncing = False
-            return {'PASS_THROUGH'}
-        elif event.type in {'WHEELUPMOUSE', 'WHEELDOWNMOUSE'} and not (event.alt or event.ctrl or event.shift or event.oskey):
-            # Since the zoom operator takes place after this, it will be delayed by one operation if we do not just handle zoom right here
-            sync_views(context, event, True)
-            return {'RUNNING_MODAL'} # Consume the event and prevent regular zoom from occuring
-        elif event.type == "RIGHTMOUSE":
-            return {"FINISHED"}
-        return {'PASS_THROUGH'}
+        if bpy.app.driver_namespace['view_sync'].has_handlers():
+            print("Removing handle")
+            bpy.app.driver_namespace['view_sync'].remove_handler()
+            del bpy.app.driver_namespace['view_sync']
+
+        return {'FINISHED'}
+
+    # def modal(self, context, event):
+    #     view3d = bpy.context.space_data
+
+    #     print(view3d.render_border_min_x, view3d.render_border_max_x)
+
+    #     for area in context.screen.areas:
+    #         if area.type == "VIEW_3D":
+    #             print(str(area) + " ", end="")
+    #     print()
+    #     if context.area is None:
+    #         return {"FINISHED"}
+    #     # TODO: Fix alt + middle mouse axis views
+    #     if event.type == 'MIDDLEMOUSE' and event.value == 'PRESS' and not event.alt:
+    #         self._syncing = True
+    #         print("Syncing")
+    #         return {'PASS_THROUGH'}
+    #     elif event.type == 'MOUSEMOVE' and self._syncing:
+    #         sync_views(context, event)
+    #         self._syncing = False
+    #         return {'PASS_THROUGH'}
+    #     elif event.type in {'WHEELUPMOUSE', 'WHEELDOWNMOUSE'} and not (event.alt or event.ctrl or event.shift or event.oskey):
+    #         # Since the zoom operator takes place after this, it will be delayed by one operation if we do not just handle zoom right here
+    #         sync_views(context, event, True)
+    #         return {'RUNNING_MODAL'}  # Consume the event and prevent regular zoom from occuring
+    #     elif event.type == "RIGHTMOUSE":
+    #         return {"FINISHED"}
+    #     return {'PASS_THROUGH'}
 
 
 def menu_func(self, context):
-    self.layout.operator(TestOperator.bl_idname, text=TestOperator.bl_label)
+    self.layout.operator(SyncviewModal.bl_idname, text=SyncviewModal.bl_label)
 
 
 # Register and add to the "object" menu (required to also use F3 search "Simple Object Operator" for quick access).
 def register():
-    bpy.utils.register_class(TestOperator)
+    bpy.utils.register_class(SyncviewModal)
     bpy.types.VIEW3D_MT_object.append(menu_func)
 
 
 def unregister():
-    bpy.utils.unregister_class(TestOperator)
+    bpy.utils.unregister_class(SyncviewModal)
     bpy.types.VIEW3D_MT_object.remove(menu_func)
 
 

--- a/__init__.py
+++ b/__init__.py
@@ -6,19 +6,20 @@ from .utils.registration import *
 # Check if addon is being reloaded
 # This also allows script.reload() to reload the addon
 if "operator_sync_view" not in locals():
-    from . import sync_handler, ui, operator_sync_view
+    from . import sync_handler, ui, operator_sync_view, msgbus
 else:
     import importlib
     sync_handler = importlib.reload(sync_handler)
     ui = importlib.reload(ui)
     operator_sync_view = importlib.reload(operator_sync_view)
+    msgbus = importlib.reload(msgbus)
 
-modules = [ui, operator_sync_view]
+modules = [operator_sync_view, msgbus, ui]
 
 bl_info = {
     "name": "Viewport Sync",
     "author": "Bowen Wu",
-    "description": "Test",
+    "description": "Syncs specified viewports to have the same views",
     "blender": (2, 80, 3),
     "version": (0, 1, 0),
     "location": "View3D > Header Bar",

--- a/__init__.py
+++ b/__init__.py
@@ -6,15 +6,16 @@ from .utils.registration import *
 # Check if addon is being reloaded
 # This also allows script.reload() to reload the addon
 if "operator_sync_view" not in locals():
-    from . import sync_handler, ui, operator_sync_view, msgbus
+    from . import sync_handler, ui, operator_sync_view, msgbus, preferences
 else:
     import importlib
     sync_handler = importlib.reload(sync_handler)
     ui = importlib.reload(ui)
     operator_sync_view = importlib.reload(operator_sync_view)
     msgbus = importlib.reload(msgbus)
+    preferences = importlib.reload(preferences)
 
-modules = [operator_sync_view, msgbus, ui]
+modules = [operator_sync_view, msgbus, ui, preferences]
 
 bl_info = {
     "name": "Viewport Sync",

--- a/__init__.py
+++ b/__init__.py
@@ -22,7 +22,7 @@ bl_info = {
     "author": "Bowen Wu",
     "description": "Syncs specified viewports to have the same views",
     "blender": (2, 80, 3),
-    "version": (0, 1, 0),
+    "version": (1, 0, 0),
     "location": "View3D > Header Bar",
     "warning": "",
     "category": "3D View"

--- a/msgbus.py
+++ b/msgbus.py
@@ -12,7 +12,7 @@ def register():
             logger.info("Enabling sync draw handler")
             bpy.ops.syncview.syncview_enable_sync()
         else:
-            bpy.app.driver_namespace['view_sync'].build_space_map()
+            bpy.app.driver_namespace['view_sync'].build_map()
 
     # Callback for when a viewport's show_sync_view RNA property changes
     key = (bpy.types.RegionView3D, "show_sync_view")

--- a/msgbus.py
+++ b/msgbus.py
@@ -7,12 +7,12 @@ def register():
     owner = driver_namespace
 
     def sync_view_callback(*args):
-        if 'view_sync' not in bpy.app.driver_namespace:
+        if 'sync_view' not in bpy.app.driver_namespace:
             logger = logging.getLogger(__name__ + ".MsgBusSyncViewCallback")
             logger.info("Enabling sync draw handler")
             bpy.ops.syncview.syncview_enable_sync()
         else:
-            bpy.app.driver_namespace['view_sync'].build_map()
+            bpy.app.driver_namespace['sync_view'].build_map()
 
     # Callback for when a viewport's show_sync_view RNA property changes
     key = (bpy.types.RegionView3D, "show_sync_view")

--- a/msgbus.py
+++ b/msgbus.py
@@ -6,14 +6,25 @@ def register():
     driver_namespace = bpy.app.driver_namespace
     owner = driver_namespace
 
-    key = (bpy.types.RegionView3D, "show_sync_view")
-
     def sync_view_callback(*args):
         if 'view_sync' not in bpy.app.driver_namespace:
             logger = logging.getLogger(__name__ + ".MsgBusSyncViewCallback")
-            logger.info("Sync enabled for a viewport, enabling sync draw handler")
+            logger.info("Enabling sync draw handler")
             bpy.ops.syncview.syncview_enable_sync()
+        else:
+            bpy.app.driver_namespace['view_sync'].build_space_map()
 
+    # Callback for when a viewport's show_sync_view RNA property changes
+    key = (bpy.types.RegionView3D, "show_sync_view")
+    bpy.msgbus.subscribe_rna(
+        key=key,
+        owner=owner,
+        args=(),
+        notify=sync_view_callback,
+    )
+
+    # Callback for when we switch viewport types
+    key = (bpy.types.Window, "workspace")
     bpy.msgbus.subscribe_rna(
         key=key,
         owner=owner,

--- a/msgbus.py
+++ b/msgbus.py
@@ -1,0 +1,27 @@
+import bpy
+import logging
+
+
+def register():
+    driver_namespace = bpy.app.driver_namespace
+    owner = driver_namespace
+
+    key = (bpy.types.RegionView3D, "show_sync_view")
+
+    def sync_view_callback(*args):
+        if 'view_sync' not in bpy.app.driver_namespace:
+            logger = logging.getLogger(__name__ + ".MsgBusSyncViewCallback")
+            logger.info("Sync enabled for a viewport, enabling sync draw handler")
+            bpy.ops.syncview.syncview_enable_sync()
+
+    bpy.msgbus.subscribe_rna(
+        key=key,
+        owner=owner,
+        args=(),
+        notify=sync_view_callback,
+    )
+
+
+def unregister():
+    driver_namespace = bpy.app.driver_namespace
+    bpy.msgbus.clear_by_owner(driver_namespace)

--- a/operator_sync_view.py
+++ b/operator_sync_view.py
@@ -4,7 +4,7 @@ from .utils.registration import *
 import logging
 
 
-class SyncView_EVENTKEYMAP_OT_mouse_move(bpy.types.Operator):
+class SYNC_VIEWEVENTKEYMAP_OT_mouse_move(bpy.types.Operator):
     """
     This operator reports the active area to our draw handler, is meant to be called through a keymap on mouse move
     Adopted from https://blender.stackexchange.com/questions/267285/alternative-to-modal-operators-blocked-autosave
@@ -28,7 +28,7 @@ class SyncView_EVENTKEYMAP_OT_mouse_move(bpy.types.Operator):
         return self.execute(context)
 
 
-class SyncView_OT_EnableSync(bpy.types.Operator):
+class SYNC_VIEWOT_EnableSync(bpy.types.Operator):
     """Enable sync view by initializing its draw handler callback"""
     bl_idname = "syncview.syncview_enable_sync"
     bl_label = "Enable Sync View Operator"
@@ -40,7 +40,7 @@ class SyncView_OT_EnableSync(bpy.types.Operator):
     def execute(self, context):
         driver_namespace = bpy.app.driver_namespace
         if 'sync_view' not in driver_namespace:
-            logger = logging.getLogger(__name__ + ".SyncView_OT_EnableSync")
+            logger = logging.getLogger(__name__ + ".SYNC_VIEWOT_EnableSync")
             logger.info("Adding SyncDrawHandler to driver_namespace['sync_view']")
             driver_namespace['sync_view'] = SyncDrawHandler()
 
@@ -50,7 +50,7 @@ class SyncView_OT_EnableSync(bpy.types.Operator):
         return self.execute(context)
 
 
-class SyncView_OT_DisableSync(bpy.types.Operator):
+class SYNC_VIEWOT_DisableSync(bpy.types.Operator):
     """Disable sync view by removing its draw handler callback"""
     bl_idname = "syncview.syncview_disable_sync"
     bl_label = "Disable Sync View Operator"
@@ -62,7 +62,7 @@ class SyncView_OT_DisableSync(bpy.types.Operator):
     def execute(self, context):
         driver_namespace = bpy.app.driver_namespace
         if 'sync_view' in driver_namespace and driver_namespace['sync_view'].has_handlers():
-            logger = logging.getLogger(__name__ + ".SyncView_OT_DisableSync")
+            logger = logging.getLogger(__name__ + ".SYNC_VIEWOT_DisableSync")
             logger.info("Removing SyncDrawHandler to driver_namespace['sync_view']")
             driver_namespace['sync_view'].remove_handler()
             del bpy.app.driver_namespace['sync_view']
@@ -73,7 +73,7 @@ class SyncView_OT_DisableSync(bpy.types.Operator):
         return self.execute(context)
 
 
-class SyncView_OT_SyncAllVisible(bpy.types.Operator):
+class SYNC_VIEWOT_SyncAllVisible(bpy.types.Operator):
     """Sync all visible viewports"""
     bl_idname = "syncview.sync_all_visible"
     bl_label = "Sync All Visible"
@@ -95,7 +95,7 @@ class SyncView_OT_SyncAllVisible(bpy.types.Operator):
         return self.execute(context)
 
 
-class SyncView_OT_StopSync(bpy.types.Operator):
+class SYNC_VIEWOT_StopSync(bpy.types.Operator):
     """Disable sync on all visible viewports"""
     bl_idname = "syncview.stop_sync_all_visible"
     bl_label = "Stop Syncing Visible"
@@ -117,8 +117,8 @@ class SyncView_OT_StopSync(bpy.types.Operator):
         return self.execute(context)
 
 
-classes = [SyncView_OT_EnableSync, SyncView_OT_DisableSync,
-           SyncView_OT_SyncAllVisible, SyncView_OT_StopSync, SyncView_EVENTKEYMAP_OT_mouse_move]
+classes = [SYNC_VIEWOT_EnableSync, SYNC_VIEWOT_DisableSync,
+           SYNC_VIEWOT_SyncAllVisible, SYNC_VIEWOT_StopSync, SYNC_VIEWEVENTKEYMAP_OT_mouse_move]
 
 
 def register():

--- a/operator_sync_view.py
+++ b/operator_sync_view.py
@@ -5,11 +5,11 @@ from .utils.registration import *
 
 class EVENTKEYMAP_OT_mouse_move(bpy.types.Operator):
     """
-    This operator reports mouse position to our draw handler, is meant to be called through a keymap on mouse move
+    This operator reports the active area to our draw handler, is meant to be called through a keymap on mouse move
     Adopted from https://blender.stackexchange.com/questions/267285/alternative-to-modal-operators-blocked-autosave
     """
-    bl_idname = "syncview.report_mouse_pos"
-    bl_label = "Report mouse position"
+    bl_idname = "syncview.report_active_area"
+    bl_label = "Report Active Area"
 
     def invoke(self, context: bpy.types.Context, event: bpy.types.Event):
         if (context is None) or (context.area is None):
@@ -21,7 +21,7 @@ class EVENTKEYMAP_OT_mouse_move(bpy.types.Operator):
 
         return {'PASS_THROUGH'}
 
-
+#TODO: Enable sync and keybind with sync toggle, and disable them with sync toggle. 
 class SyncView_OT_Enable_Sync(bpy.types.Operator):
     """"""
     bl_idname = "syncview.syncview_enable_sync"
@@ -64,14 +64,14 @@ def register():
     # Keyamp bs: https://blender.stackexchange.com/questions/200811/is-there-a-reference-for-how-to-add-custom-keymaps-to-operators-in-an-addon
     if keyconfigs_addon:
         keymap_sync_view = keyconfigs_addon.keymaps.new(name="3D View", space_type='VIEW_3D')
-        keymap_sync_view.keymap_items.new(idname="syncview.report_mouse_pos", type='MOUSEMOVE', value='ANY')
+        keymap_sync_view.keymap_items.new(idname="syncview.report_active_area", type='MOUSEMOVE', value='ANY')
 
 
 def unregister():
     keyconfigs_addon = bpy.context.window_manager.keyconfigs.addon
     if keyconfigs_addon:
         keymap = keyconfigs_addon.keymaps.find("3D View", space_type="VIEW_3D")
-        keymap_item = keymap.keymap_items.find_from_operator(idname="syncview.report_mouse_pos")
+        keymap_item = keymap.keymap_items.find_from_operator(idname="syncview.report_active_area")
 
         keymap.keymap_items.remove(keymap_item)
         keyconfigs_addon.keymaps.remove(keymap)

--- a/operator_sync_view.py
+++ b/operator_sync_view.py
@@ -16,17 +16,20 @@ class EVENTKEYMAP_OT_mouse_move(bpy.types.Operator):
     def poll(cls, context):
         return context and context.area
 
-    def invoke(self, context: bpy.types.Context, event: bpy.types.Event):
+    def execute(self, context: bpy.types.Context):
         if 'view_sync' in bpy.app.driver_namespace:
             view_sync = bpy.app.driver_namespace['view_sync']
-            view_sync.active_area = context.area
+            view_sync.active_space = context.area.spaces.active
             view_sync.active_window = context.window
 
         return {'PASS_THROUGH'}
 
+    def invoke(self, context: bpy.types.Context, event: bpy.types.Event):
+        return self.execute(context)
+
 
 class SyncView_OT_Enable_Sync(bpy.types.Operator):
-    """"""
+    """Enable sync view by initializing its draw handler callback"""
     bl_idname = "syncview.syncview_enable_sync"
     bl_label = "Enable Sync View Operator"
 
@@ -36,6 +39,7 @@ class SyncView_OT_Enable_Sync(bpy.types.Operator):
 
     def execute(self, context):
         driver_namespace = bpy.app.driver_namespace
+        # TODO: Change view_sync to sync_view
         if 'view_sync' not in driver_namespace:
             logger = logging.getLogger(__name__ + ".SyncView_OT_Enable_Sync")
             logger.info("Adding SyncDrawHandler to driver_namespace['view_sync']")
@@ -47,7 +51,7 @@ class SyncView_OT_Enable_Sync(bpy.types.Operator):
 
 
 class SyncView_OT_Disable_Sync(bpy.types.Operator):
-    """"""
+    """Disable sync view by removing its draw handler callback"""
     bl_idname = "syncview.syncview_disable_sync"
     bl_label = "Disable Sync View Operator"
 

--- a/operator_sync_view.py
+++ b/operator_sync_view.py
@@ -5,14 +5,14 @@ from .utils.registration import *
 
 class EVENTKEYMAP_OT_mouse_move(bpy.types.Operator):
     """
-    This operator reports mouse position to our draw handler,
+    This operator reports mouse position to our draw handler, is meant to be called through a keymap on mouse move
     Adopted from https://blender.stackexchange.com/questions/267285/alternative-to-modal-operators-blocked-autosave
     """
     bl_idname = "syncview.report_mouse_pos"
     bl_label = "Report mouse position"
 
     def invoke(self, context: bpy.types.Context, event: bpy.types.Event):
-        if (context is None) or (event is None) or (not context is None and context.region is None):
+        if (context is None) or (context.area is None):
             return {'PASS_THROUGH'}
 
         if 'view_sync' in bpy.app.driver_namespace:
@@ -28,9 +28,9 @@ class SyncView_OT_Enable_Sync(bpy.types.Operator):
     bl_label = "Enable Sync View Operator"
 
     def execute(self, context):
-        if 'view_sync' not in bpy.app.driver_namespace:
-            # context.window_manager.modal_handler_add(self)
-            bpy.app.driver_namespace['view_sync'] = SyncDrawHandler()
+        driver_namespace = bpy.app.driver_namespace
+        if 'view_sync' not in driver_namespace:
+            driver_namespace['view_sync'] = SyncDrawHandler()
         return {'FINISHED'}
 
     def invoke(self, context: bpy.types.Context, event: bpy.types.Event):

--- a/operator_sync_view.py
+++ b/operator_sync_view.py
@@ -43,6 +43,7 @@ class SyncView_OT_EnableSync(bpy.types.Operator):
             logger = logging.getLogger(__name__ + ".SyncView_OT_EnableSync")
             logger.info("Adding SyncDrawHandler to driver_namespace['sync_view']")
             driver_namespace['sync_view'] = SyncDrawHandler()
+
         return {'FINISHED'}
 
     def invoke(self, context: bpy.types.Context, event: bpy.types.Event):
@@ -87,6 +88,7 @@ class SyncView_OT_SyncAllVisible(bpy.types.Operator):
                 if area.type == "VIEW_3D":
                     if area.spaces.active:
                         area.spaces.active.region_3d.show_sync_view = True
+
         return {'FINISHED'}
 
     def invoke(self, context: bpy.types.Context, event: bpy.types.Event):
@@ -108,6 +110,7 @@ class SyncView_OT_StopSync(bpy.types.Operator):
                 if area.type == "VIEW_3D":
                     if area.spaces.active:
                         area.spaces.active.region_3d.show_sync_view = False
+
         return {'FINISHED'}
 
     def invoke(self, context: bpy.types.Context, event: bpy.types.Event):

--- a/operator_sync_view.py
+++ b/operator_sync_view.py
@@ -17,11 +17,11 @@ class EVENTKEYMAP_OT_mouse_move(bpy.types.Operator):
         return context and context.area
 
     def execute(self, context: bpy.types.Context):
-        if 'view_sync' in bpy.app.driver_namespace:
-            view_sync = bpy.app.driver_namespace['view_sync']
-            view_sync.active_area = context.area
-            view_sync.active_space = context.area.spaces.active
-            view_sync.active_window = context.window
+        if 'sync_view' in bpy.app.driver_namespace:
+            sync_view = bpy.app.driver_namespace['sync_view']
+            sync_view.active_area = context.area
+            sync_view.active_space = context.area.spaces.active
+            sync_view.active_window = context.window
 
         return {'PASS_THROUGH'}
 
@@ -40,11 +40,10 @@ class SyncView_OT_EnableSync(bpy.types.Operator):
 
     def execute(self, context):
         driver_namespace = bpy.app.driver_namespace
-        # TODO: Change view_sync to sync_view
-        if 'view_sync' not in driver_namespace:
+        if 'sync_view' not in driver_namespace:
             logger = logging.getLogger(__name__ + ".SyncView_OT_EnableSync")
-            logger.info("Adding SyncDrawHandler to driver_namespace['view_sync']")
-            driver_namespace['view_sync'] = SyncDrawHandler()
+            logger.info("Adding SyncDrawHandler to driver_namespace['sync_view']")
+            driver_namespace['sync_view'] = SyncDrawHandler()
         return {'FINISHED'}
 
     def invoke(self, context: bpy.types.Context, event: bpy.types.Event):
@@ -62,11 +61,11 @@ class SyncView_OT_DisableSync(bpy.types.Operator):
 
     def execute(self, context):
         driver_namespace = bpy.app.driver_namespace
-        if 'view_sync' in driver_namespace and driver_namespace['view_sync'].has_handlers():
+        if 'sync_view' in driver_namespace and driver_namespace['sync_view'].has_handlers():
             logger = logging.getLogger(__name__ + ".SyncView_OT_DisableSync")
-            logger.info("Removing SyncDrawHandler to driver_namespace['view_sync']")
-            driver_namespace['view_sync'].remove_handler()
-            del bpy.app.driver_namespace['view_sync']
+            logger.info("Removing SyncDrawHandler to driver_namespace['sync_view']")
+            driver_namespace['sync_view'].remove_handler()
+            del bpy.app.driver_namespace['sync_view']
 
         return {'FINISHED'}
 
@@ -133,9 +132,9 @@ def register():
 
 def unregister():
     driver_namespace = bpy.app.driver_namespace
-    if 'view_sync' in driver_namespace and driver_namespace['view_sync'].has_handlers():
-        driver_namespace['view_sync'].remove_handlers()
-        del bpy.app.driver_namespace['view_sync']
+    if 'sync_view' in driver_namespace and driver_namespace['sync_view'].has_handlers():
+        driver_namespace['sync_view'].remove_handlers()
+        del bpy.app.driver_namespace['sync_view']
 
     # Reset attributes, it's not supposed to be True outside of this addon
     for window in bpy.context.window_manager.windows:

--- a/operator_sync_view.py
+++ b/operator_sync_view.py
@@ -5,7 +5,7 @@ from .utils.registration import *
 
 class EVENTKEYMAP_OT_mouse_move(bpy.types.Operator):
     """
-    This operator reports mouse position to our draw handler, 
+    This operator reports mouse position to our draw handler,
     Adopted from https://blender.stackexchange.com/questions/267285/alternative-to-modal-operators-blocked-autosave
     """
     bl_idname = "syncview.report_mouse_pos"

--- a/operator_sync_view.py
+++ b/operator_sync_view.py
@@ -19,7 +19,6 @@ class SyncView_EVENTKEYMAP_OT_mouse_move(bpy.types.Operator):
     def execute(self, context: bpy.types.Context):
         if 'sync_view' in bpy.app.driver_namespace:
             sync_view = bpy.app.driver_namespace['sync_view']
-            sync_view.active_area = context.area
             sync_view.active_space = context.area.spaces.active
             sync_view.active_window = context.window
 
@@ -74,6 +73,7 @@ class SyncView_OT_DisableSync(bpy.types.Operator):
 
 
 class SyncView_OT_SyncAllVisible(bpy.types.Operator):
+    """Sync all visible viewports"""
     bl_idname = "syncview.sync_all_visible"
     bl_label = "Sync All Visible"
 
@@ -94,6 +94,7 @@ class SyncView_OT_SyncAllVisible(bpy.types.Operator):
 
 
 class SyncView_OT_StopSync(bpy.types.Operator):
+    """Disable sync on all visible viewports"""
     bl_idname = "syncview.stop_sync_all_visible"
     bl_label = "Stop Syncing Visible"
 

--- a/operator_sync_view.py
+++ b/operator_sync_view.py
@@ -4,7 +4,7 @@ from .utils.registration import *
 import logging
 
 
-class EVENTKEYMAP_OT_mouse_move(bpy.types.Operator):
+class SyncView_EVENTKEYMAP_OT_mouse_move(bpy.types.Operator):
     """
     This operator reports the active area to our draw handler, is meant to be called through a keymap on mouse move
     Adopted from https://blender.stackexchange.com/questions/267285/alternative-to-modal-operators-blocked-autosave
@@ -114,7 +114,7 @@ class SyncView_OT_StopSync(bpy.types.Operator):
 
 
 classes = [SyncView_OT_EnableSync, SyncView_OT_DisableSync,
-           SyncView_OT_SyncAllVisible, SyncView_OT_StopSync, EVENTKEYMAP_OT_mouse_move]
+           SyncView_OT_SyncAllVisible, SyncView_OT_StopSync, SyncView_EVENTKEYMAP_OT_mouse_move]
 
 
 def register():

--- a/operator_sync_view.py
+++ b/operator_sync_view.py
@@ -3,33 +3,44 @@ from .sync_handler import SyncDrawHandler
 from .utils.registration import *
 
 
-class SyncView_OT_Enable_Sync_Modal(bpy.types.Operator):
-    """"""
-    bl_idname = "syncview.syncview_enable_syncmodal"
-    bl_label = "Enable Sync View Modal Operator"
+class EVENTKEYMAP_OT_mouse_move(bpy.types.Operator):
+    """
+    This operator reports mouse position to our draw handler, 
+    Adopted from https://blender.stackexchange.com/questions/267285/alternative-to-modal-operators-blocked-autosave
+    """
+    bl_idname = "syncview.report_mouse_pos"
+    bl_label = "Report mouse position"
 
-    def modal(self, context, event):
+    def invoke(self, context: bpy.types.Context, event: bpy.types.Event):
+        if (context is None) or (event is None) or (not context is None and context.region is None):
+            return {'PASS_THROUGH'}
+
         if 'view_sync' in bpy.app.driver_namespace:
-            bpy.app.driver_namespace['view_sync'].update_mouse_pos((event.mouse_x, event.mouse_y))
-            return {"PASS_THROUGH"}
-        else:
-            print("Ending modal")
-            return {'FINISHED'}
+            view_sync = bpy.app.driver_namespace['view_sync']
+            view_sync.active_area = context.area
+
+        return {'PASS_THROUGH'}
+
+
+class SyncView_OT_Enable_Sync(bpy.types.Operator):
+    """"""
+    bl_idname = "syncview.syncview_enable_sync"
+    bl_label = "Enable Sync View Operator"
 
     def execute(self, context):
         if 'view_sync' not in bpy.app.driver_namespace:
-            context.window_manager.modal_handler_add(self)
+            # context.window_manager.modal_handler_add(self)
             bpy.app.driver_namespace['view_sync'] = SyncDrawHandler()
-        return {'RUNNING_MODAL'}
+        return {'FINISHED'}
 
     def invoke(self, context: bpy.types.Context, event: bpy.types.Event):
         return self.execute(context)
 
 
-class SyncView_OT_Disable_Sync_Modal(bpy.types.Operator):
+class SyncView_OT_Disable_Sync(bpy.types.Operator):
     """"""
-    bl_idname = "syncview.syncview_disable_syncmodal"
-    bl_label = "Disable Sync View Modal Operator"
+    bl_idname = "syncview.syncview_disable_sync"
+    bl_label = "Disable Sync View Operator"
 
     def execute(self, context):
         driver_namespace = bpy.app.driver_namespace
@@ -43,13 +54,26 @@ class SyncView_OT_Disable_Sync_Modal(bpy.types.Operator):
         return self.execute(context)
 
 
-classes = [SyncView_OT_Enable_Sync_Modal, SyncView_OT_Disable_Sync_Modal]
+classes = [SyncView_OT_Enable_Sync, SyncView_OT_Disable_Sync, EVENTKEYMAP_OT_mouse_move]
 
 
 def register():
-    print("Registering sync view")
     register_classes(classes)
+
+    keyconfigs_addon = bpy.context.window_manager.keyconfigs.addon
+    # Keyamp bs: https://blender.stackexchange.com/questions/200811/is-there-a-reference-for-how-to-add-custom-keymaps-to-operators-in-an-addon
+    if keyconfigs_addon:
+        keymap_sync_view = keyconfigs_addon.keymaps.new(name="3D View", space_type='VIEW_3D')
+        keymap_sync_view.keymap_items.new(idname="syncview.report_mouse_pos", type='MOUSEMOVE', value='ANY')
 
 
 def unregister():
+    keyconfigs_addon = bpy.context.window_manager.keyconfigs.addon
+    if keyconfigs_addon:
+        keymap = keyconfigs_addon.keymaps.find("3D View", space_type="VIEW_3D")
+        keymap_item = keymap.keymap_items.find_from_operator(idname="syncview.report_mouse_pos")
+
+        keymap.keymap_items.remove(keymap_item)
+        keyconfigs_addon.keymaps.remove(keymap)
+
     unregister_classes(classes)

--- a/operator_sync_view.py
+++ b/operator_sync_view.py
@@ -75,7 +75,7 @@ class SyncView_OT_DisableSync(bpy.types.Operator):
 
 class SyncView_OT_SyncAllVisible(bpy.types.Operator):
     bl_idname = "syncview.sync_all_visible"
-    bl_label = "Sync All Visible Viewports"
+    bl_label = "Sync All Visible"
 
     @classmethod
     def poll(cls, context):
@@ -95,7 +95,7 @@ class SyncView_OT_SyncAllVisible(bpy.types.Operator):
 
 class SyncView_OT_StopSync(bpy.types.Operator):
     bl_idname = "syncview.stop_sync_all_visible"
-    bl_label = "Stop Syncing Visible Viewports"
+    bl_label = "Stop Syncing Visible"
 
     @classmethod
     def poll(cls, context):

--- a/operator_sync_view.py
+++ b/operator_sync_view.py
@@ -1,0 +1,55 @@
+import bpy
+from .sync_handler import SyncDrawHandler
+from .utils.registration import *
+
+
+class SyncView_OT_Enable_Sync_Modal(bpy.types.Operator):
+    """"""
+    bl_idname = "syncview.syncview_enable_syncmodal"
+    bl_label = "Enable Sync View Modal Operator"
+
+    def modal(self, context, event):
+        if 'view_sync' in bpy.app.driver_namespace:
+            bpy.app.driver_namespace['view_sync'].update_mouse_pos((event.mouse_x, event.mouse_y))
+            return {"PASS_THROUGH"}
+        else:
+            print("Ending modal")
+            return {'FINISHED'}
+
+    def execute(self, context):
+        if 'view_sync' not in bpy.app.driver_namespace:
+            context.window_manager.modal_handler_add(self)
+            bpy.app.driver_namespace['view_sync'] = SyncDrawHandler()
+        return {'RUNNING_MODAL'}
+
+    def invoke(self, context: bpy.types.Context, event: bpy.types.Event):
+        return self.execute(context)
+
+
+class SyncView_OT_Disable_Sync_Modal(bpy.types.Operator):
+    """"""
+    bl_idname = "syncview.syncview_disable_syncmodal"
+    bl_label = "Disable Sync View Modal Operator"
+
+    def execute(self, context):
+        driver_namespace = bpy.app.driver_namespace
+        if 'view_sync' in driver_namespace and driver_namespace['view_sync'].has_handlers():
+            driver_namespace['view_sync'].remove_handler()
+            del bpy.app.driver_namespace['view_sync']
+
+        return {'FINISHED'}
+
+    def invoke(self, context: bpy.types.Context, event: bpy.types.Event):
+        return self.execute(context)
+
+
+classes = [SyncView_OT_Enable_Sync_Modal, SyncView_OT_Disable_Sync_Modal]
+
+
+def register():
+    print("Registering sync view")
+    register_classes(classes)
+
+
+def unregister():
+    unregister_classes(classes)

--- a/preferences.py
+++ b/preferences.py
@@ -1,0 +1,41 @@
+import bpy
+from bpy.types import AddonPreferences
+from bpy.props import EnumProperty
+
+
+class SyncViewPreferences(AddonPreferences):
+    bl_idname = __package__
+
+    sync_modes = {
+        'Window': 0,
+        'Workspace': 1,
+        'All': 2
+    }
+
+    def enum_update(self, context):
+        if 'view_sync' in bpy.app.driver_namespace:
+            bpy.app.driver_namespace['view_sync'].build_space_map()
+
+    sync_mode: EnumProperty(
+        name="Sync Mode",
+        items=[
+            ('Window', 'Sync Window', 'Sync viewports within the same window', 'WINDOW', 0),
+            ('Workspace', 'Sync Workspace', 'Sync viewports within the same workspace', 'WORKSPACE', 1),
+            ('All', 'Sync All', 'Sync all viewports in the blend file', 'FILE_BLEND', 2)
+        ],
+        description="Determines what viewports to sync",
+        default=0,
+        update=enum_update
+    )
+
+    def draw(self, context):
+        layout = self.layout
+        layout.props_enum(self, "sync_mode")
+
+
+def register():
+    bpy.utils.register_class(SyncViewPreferences)
+
+
+def unregister():
+    bpy.utils.unregister_class(SyncViewPreferences)

--- a/preferences.py
+++ b/preferences.py
@@ -1,6 +1,6 @@
 import bpy
 from bpy.types import AddonPreferences
-from bpy.props import EnumProperty
+from bpy.props import EnumProperty, BoolProperty
 
 
 class SyncViewPreferences(AddonPreferences):
@@ -28,9 +28,31 @@ class SyncViewPreferences(AddonPreferences):
         update=enum_update
     )
 
+    pause_sync: BoolProperty(
+        name="Pause Sync",
+        description="Temporarily Pause Sync",
+        default=False,
+    )
+
+    pause_sync_during_playback: BoolProperty(
+        name="Pause Sync During Playback",
+        description="Pause Sync During Playback",
+        default=False,
+    )
+
+    sync_camera_view: BoolProperty(
+        name="Sync viewports in camera view",
+        description="Sync viewports in camera view",
+        default=True,
+    )
+
     def draw(self, context):
         layout = self.layout
         layout.props_enum(self, "sync_mode")
+        row = layout.row()
+        row.prop(self, "pause_sync")
+        row.prop(self, "pause_sync_during_playback")
+        row.prop(self, "sync_camera_view")
 
 
 def register():

--- a/preferences.py
+++ b/preferences.py
@@ -34,15 +34,15 @@ class SyncViewPreferences(AddonPreferences):
         default=False,
     )
 
-    pause_sync_during_playback: BoolProperty(
-        name="Pause Sync During Playback",
-        description="Pause Sync During Playback",
-        default=False,
+    sync_playback: BoolProperty(
+        name="Sync Playback",
+        description="Sync During Playback",
+        default=True,
     )
 
     sync_camera_view: BoolProperty(
-        name="Sync viewports in camera view",
-        description="Sync viewports in camera view",
+        name="Sync Camera View",
+        description="Sync Viewports in Camera View",
         default=True,
     )
 
@@ -51,7 +51,7 @@ class SyncViewPreferences(AddonPreferences):
         layout.props_enum(self, "sync_mode")
         row = layout.row()
         row.prop(self, "pause_sync")
-        row.prop(self, "pause_sync_during_playback")
+        row.prop(self, "sync_playback")
         row.prop(self, "sync_camera_view")
 
 

--- a/preferences.py
+++ b/preferences.py
@@ -14,7 +14,7 @@ class SyncViewPreferences(AddonPreferences):
 
     def enum_update(self, context):
         if 'view_sync' in bpy.app.driver_namespace:
-            bpy.app.driver_namespace['view_sync'].build_space_map()
+            bpy.app.driver_namespace['view_sync'].build_map()
 
     sync_mode: EnumProperty(
         name="Sync Mode",

--- a/preferences.py
+++ b/preferences.py
@@ -13,8 +13,8 @@ class SyncViewPreferences(AddonPreferences):
     }
 
     def enum_update(self, context):
-        if 'view_sync' in bpy.app.driver_namespace:
-            bpy.app.driver_namespace['view_sync'].build_map()
+        if 'sync_view' in bpy.app.driver_namespace:
+            bpy.app.driver_namespace['sync_view'].build_map()
 
     sync_mode: EnumProperty(
         name="Sync Mode",

--- a/sync_handler.py
+++ b/sync_handler.py
@@ -11,7 +11,7 @@ def update_space(source_space, target_space):
     # Update space attributes
     space_attributes = ['clip_end', 'clip_start', 'lens']
     update_attributes(source_space, target_space, space_attributes)
-    
+
     # Update ViewRegion3D attributes
     # All modifiable attributes
     view_region_3d_attributes = ['clip_planes', 'is_orthographic_side_view', 'is_perspective', 'lock_rotation', 'show_sync_view', 'use_box_clip', 'use_clip_planes',

--- a/sync_handler.py
+++ b/sync_handler.py
@@ -170,8 +170,6 @@ class SyncDrawHandler:
     def has_handlers(self):
         return len(self._handlers) > 0
 
-    # TODO: Have option to turn off sync temporarily
-    # TODO: Have option to turn off sync during animation playback
     def sync_draw_callback(self):
         this_space = bpy.context.space_data
 

--- a/sync_handler.py
+++ b/sync_handler.py
@@ -176,7 +176,7 @@ class SyncDrawHandler:
         if self._preferences.pause_sync:
             return
 
-        if bpy.context.screen.is_animation_playing and self._preferences.pause_sync_during_playback:
+        if bpy.context.screen.is_animation_playing and not self._preferences.sync_playback:
             return
 
         if not self._preferences.sync_camera_view and bpy.context.space_data.region_3d.view_perspective == "CAMERA":

--- a/sync_handler.py
+++ b/sync_handler.py
@@ -23,37 +23,106 @@ def update_space(source_space, target_space):
 
 class SyncDrawHandler:
     def __init__(self):
+        self.active_space: bpy.types.Space = None
+
         self._handlers = []
-        self.active_area = None
         self._active_window = None
         self._skip_sync: bool = False
-        self._areas: Set[bpy.types.Area] = set()
+        self._spaces: Set[bpy.types.Space] = set()
         self._logger = logging.getLogger(__name__ + ".SyncDrawHandler")
+        self._space_map = dict()
+        self._preferences = bpy.context.preferences.addons[__package__].preferences
+        self._lock_sync = False  # Rendering is done on a separate thread, this is to prevent race conditions
         self.__add_handlers()
 
-    def __del__(self):
-        self.remove_handlers()
-
     def set_active_window(self, new_window: bpy.types.Window):
+        self._lock_sync = True
         if self._active_window != new_window:
-            self._areas = set()
-            for area in new_window.screen.areas:
-                if area.type == "VIEW_3D" and area.spaces[0].region_3d.show_sync_view:
-                    self._areas.add(area)
+            self.__rebuild_space_map(new_window)
+        self._lock_sync = False
         self._active_window = new_window
 
     active_window = property(fset=set_active_window)
+
+    def __rebuild_window(self, new_window: bpy.types.Window):
+        self._spaces = set()
+        self._space_map = dict()
+        if "sync_view.do_not_sync" not in new_window.screen:
+            for area in new_window.screen.areas:
+                if area.type == "VIEW_3D" and area.spaces.active.region_3d.show_sync_view:
+                    self._spaces.add(area.spaces.active)
+                    self._space_map[area.spaces.active] = (new_window.workspace, new_window.screen)
+
+    def __rebuild_space_map(self, new_window):
+        sync_mode = self._preferences.sync_modes[self._preferences.sync_mode]
+        match sync_mode:
+            case 0:  # Window Sync
+                self.__rebuild_window(new_window)
+            case 1:  # Workspace sync
+                self._spaces = set()
+                self._space_map = dict()
+
+                # Use the workspace of an open window instead of bpy.context.workspace
+                # because for some reason those two can be different
+                workspace_window_any = bpy.context.window_manager.windows[0]
+                workspace, screens = workspace_window_any.workspace, workspace_window_any.workspace.screens
+
+                valid_screens = {
+                    window.screen for window in bpy.context.window_manager.windows if "sync_view.do_not_sync" not in window.screen}
+                for screen in screens:
+                    if screen in valid_screens and hasattr(screen, "areas"):
+                        for area in screen.areas:
+                            active_space = area.spaces.active
+                            if area.type == "VIEW_3D" and active_space and active_space.region_3d.show_sync_view:
+                                self._spaces.add(active_space)
+                                self._space_map[active_space] = (workspace, screen)
+                    else:  # These should be screens that are closed in the current workspace
+                        screen["sync_view.do_not_sync"] = True
+            case 2:  # All Sync
+                self._spaces = set()
+                self._space_map = dict()
+
+                # Use the workspace of an open window instead of bpy.context.workspace
+                # because for some reason those two can be different
+                workspace_window_any = bpy.context.window_manager.windows[0]
+                workspace_screens = set(workspace_window_any.workspace.screens)
+                valid_workspace_screens = {
+                    window.screen for window in bpy.context.window_manager.windows if "sync_view.do_not_sync" not in window.screen}
+                # We cannot be certain if a screen outside of the current workspace is closed and should not be synced
+                other_workspace_screens = {
+                    screen for screen in bpy.context.blend_data.screens
+                    if ("sync_view.do_not_sync" not in screen and screen not in workspace_screens)}
+
+                screens = valid_workspace_screens.union(other_workspace_screens)
+
+                for workspace in bpy.context.blend_data.workspaces:
+                    for screen in workspace.screens:
+                        if screen in screens and hasattr(screen, "areas"):
+                            for area in screen.areas:
+                                active_space = area.spaces.active
+                                if area.type == "VIEW_3D" and active_space and active_space.region_3d.show_sync_view:
+                                    self._spaces.add(active_space)
+                                    self._space_map[active_space] = (workspace_window_any.workspace, screen)
+                        else:  # These should be screens that are closed in the current workspace
+                            screen["sync_view.do_not_sync"] = True
+            case _:
+                self.__rebuild_window(new_window)
+
+    def build_space_map(self):
+        self._lock_sync = True
+        self.__rebuild_space_map(self._active_window)
+        self._lock_sync = False
 
     # Handler order: PRE_VIEW, POST_VIEW, POST_PIXEL
 
     def __add_handlers(self):
         self._handlers.append(bpy.types.SpaceView3D.draw_handler_add(
             self.sync_draw_callback, (), 'WINDOW', 'PRE_VIEW'))
-        self._logger.info("Adding a draw handler")
+        self._logger.info("Adding a sync view draw handler")
         self._logger.info("Handlers: " + str(self._handlers))
 
     def remove_handlers(self):
-        self._logger.info("Removing view sync draw handlers")
+        self._logger.info("Removing sync view draw handlers")
         for handler in self._handlers:
             bpy.types.SpaceView3D.draw_handler_remove(handler, 'WINDOW')
         self._handlers = []
@@ -61,31 +130,61 @@ class SyncDrawHandler:
     def has_handlers(self):
         return len(self._handlers) > 0
 
+    # TODO: Time our sync callback comapred to areas solution
     def sync_draw_callback(self):
-        if not bpy.context.region_data.show_sync_view or not self.active_area or not self._active_window:
-            self._areas.discard(bpy.context.area)
+        if self._lock_sync:
             return
 
-        self._areas.add(bpy.context.area)
+        this_space = bpy.context.space_data
+        if not bpy.context.region_data.show_sync_view or not self.active_space:
+            self._spaces.discard(this_space)
+            return
 
-        # Cleanup invalid areas
-        invalid_areas = set()
-        for area in self._areas:
-            if not area.path_resolve("height") or area not in self._active_window.screen.areas.values():
-                invalid_areas.add(area)
-        for area in invalid_areas:
-            self._areas.remove(area)
+        # Use the workspace of an open window instead of bpy.context.workspace
+        # because for some reason those two can be different
+        self._space_map[this_space] = (bpy.context.window_manager.windows[0].workspace, bpy.context.screen)
+        self._spaces.add(this_space)
 
         # Sync other viewports
-        if bpy.context.area == self.active_area:
+        if this_space == self.active_space:
             # For some reason updating another viewport causes this viewport to have an additional redraw, so we skip
             if self._skip_sync:
                 self._skip_sync = False
                 return
             self._skip_sync = True
 
-            # TODO: conditionally loop over all windows and screens to sync between windows.
-            for area in self._areas:
-                if area != bpy.context.area and area.spaces[0].region_3d.show_sync_view:
-                    update_space(bpy.context.area.spaces[0], area.spaces[0])
+            # Cleanup invalid spaces
+            sync_mode = self._preferences.sync_modes[self._preferences.sync_mode]
+            # Use .region_3d to check if viewport is still valid
+            match sync_mode:
+                case 0:  # Window Sync
+                    self._spaces = {
+                        space for space in self._spaces
+                        if (space.region_3d and
+                            self._space_map[space][1] == self._space_map[self.active_space][1]
+                            )
+                    }
+                case 1:  # Workspace Sync
+                    self._spaces = {
+                        space for space in self._spaces
+                        if (space.region_3d and
+                            self._space_map[space][0] == self._space_map[self.active_space][0]
+                            )
+                    }
+                case 2:  # All Sync
+                    self._spaces = {
+                        space for space in self._spaces
+                        if space.region_3d
+                    }
+                case _:  # Default to Window Sync
+                    self._spaces = {
+                        space for space in self._spaces
+                        if (space.region_3d and
+                            self._space_map[space][1] == self._space_map[self.active_space][1]
+                            )
+                    }
+            self._spaces.remove(this_space)
+            for space in self._spaces:
+                if space.region_3d.show_sync_view:
+                    update_space(this_space, space)
         return

--- a/sync_handler.py
+++ b/sync_handler.py
@@ -24,7 +24,7 @@ class SyncDrawHandler:
     def __init__(self):
         self.add_handler()
         self.source_area = None
-        self.mouse_pos = (0, 0)
+        self.active_area = None
         self.skip_sync = False
 
     # Handler order: PRE_VIEW, POST_VIEW, POST_PIXEL
@@ -36,36 +36,26 @@ class SyncDrawHandler:
     def has_handlers(self):
         return len(self.handlers) > 0
 
-    def update_mouse_pos(self, mouse_pos):
-        self.mouse_pos = mouse_pos
-
-    def mouse_is_in_area(self, area_window_min, area_window_max):
-        return not ((self.mouse_pos[0] < area_window_min[0]) or (self.mouse_pos[0] > area_window_max[0]) or (self.mouse_pos[1] < area_window_min[1]) or (self.mouse_pos[1] > area_window_max[1]))
-
     def sync_draw_callback(self):
         context = bpy.context
-        area_window_min = (context.area.x, context.area.y)
-        area_window_max = (context.area.x + context.area.width, context.area.y + context.area.height)
-        if not bpy.context.region_data.show_sync_view:
+        if not context.region_data.show_sync_view:
             return
 
         this_area = context.area
 
         # Small optimization: Python evaluates conditions lazily, so if first conditions succeeds we don't need to do any work to check the second condition
-        if self.source_area == this_area or self.mouse_is_in_area(area_window_min, area_window_max):
+        if this_area == self.active_area:
+            self.source_area = this_area
             # For some reason updating another viewport causes this viewport to have an additional redraw, so we skip
             if self.skip_sync:
                 self.skip_sync = False
                 return
             self.skip_sync = True
 
-            self.source_area = this_area
-            for window in context.window_manager.windows:
-                for area in window.screen.areas:
-                    if area.type == "VIEW_3D" and area != this_area:
-                        if area.spaces[0].region_3d.show_sync_view:
-                            update_space(this_area.spaces[0], area.spaces[0])
-
+            for area in context.screen.areas:
+                if area.type == "VIEW_3D" and area != this_area:
+                    if area.spaces[0].region_3d.show_sync_view:
+                        update_space(this_area.spaces[0], area.spaces[0])
         return
 
     def remove_handler(self):

--- a/sync_handler.py
+++ b/sync_handler.py
@@ -108,7 +108,7 @@ class SyncDrawHandler:
             case _:
                 self.__rebuild_window(new_window)
 
-    def build_space_map(self):
+    def build_map(self):
         self._lock_sync = True
         self.__rebuild_space_map(self._active_window)
         self._lock_sync = False

--- a/sync_handler.py
+++ b/sync_handler.py
@@ -8,16 +8,15 @@ def update_space(source_space, target_space):
             if new_attribute is not None:
                 setattr(target, attribute, new_attribute)
 
-    # Update space attributes, causes 2 additional redraws on target
+    # Update space attributes
     space_attributes = ['clip_end', 'clip_start', 'lens']
     update_attributes(source_space, target_space, space_attributes)
+    
     # Update ViewRegion3D attributes
-    # All modifiable attributes, causes 8 additional redraws on target
+    # All modifiable attributes
     view_region_3d_attributes = ['clip_planes', 'is_orthographic_side_view', 'is_perspective', 'lock_rotation', 'show_sync_view', 'use_box_clip', 'use_clip_planes',
                                  'view_camera_offset', 'view_camera_zoom', 'view_distance', 'view_location', 'view_perspective', 'view_rotation']
     update_attributes(source_space.region_3d, target_space.region_3d, view_region_3d_attributes)
-
-# Issue: Our modal operator to report our mouse position is removed on loading a new file, and does not work on a new window
 
 
 class SyncDrawHandler:
@@ -43,7 +42,6 @@ class SyncDrawHandler:
 
         this_area = context.area
 
-        # Small optimization: Python evaluates conditions lazily, so if first conditions succeeds we don't need to do any work to check the second condition
         if this_area == self.active_area:
             self.source_area = this_area
             # For some reason updating another viewport causes this viewport to have an additional redraw, so we skip

--- a/sync_handler.py
+++ b/sync_handler.py
@@ -1,4 +1,6 @@
 import bpy
+from typing import Set
+import logging
 
 
 def update_space(source_space, target_space):
@@ -14,51 +16,76 @@ def update_space(source_space, target_space):
 
     # Update ViewRegion3D attributes
     # All modifiable attributes
-    view_region_3d_attributes = ['clip_planes', 'is_orthographic_side_view', 'is_perspective', 'lock_rotation', 'show_sync_view', 'use_box_clip', 'use_clip_planes',
+    view_region_3d_attributes = ['clip_planes', 'is_orthographic_side_view', 'is_perspective', 'lock_rotation', 'use_box_clip', 'use_clip_planes',
                                  'view_camera_offset', 'view_camera_zoom', 'view_distance', 'view_location', 'view_perspective', 'view_rotation']
     update_attributes(source_space.region_3d, target_space.region_3d, view_region_3d_attributes)
 
 
 class SyncDrawHandler:
     def __init__(self):
-        self.add_handler()
-        self.source_area = None
+        self._handlers = []
         self.active_area = None
-        self.skip_sync = False
+        self._active_window = None
+        self._skip_sync: bool = False
+        self._areas: Set[bpy.types.Area] = set()
+        self._logger = logging.getLogger(__name__ + ".SyncDrawHandler")
+        self.__add_handlers()
+
+    def __del__(self):
+        self.remove_handlers()
+
+    def set_active_window(self, new_window: bpy.types.Window):
+        if self._active_window != new_window:
+            self._areas = set()
+            for area in new_window.screen.areas:
+                if area.type == "VIEW_3D" and area.spaces[0].region_3d.show_sync_view:
+                    self._areas.add(area)
+        self._active_window = new_window
+
+    active_window = property(fset=set_active_window)
 
     # Handler order: PRE_VIEW, POST_VIEW, POST_PIXEL
-    def add_handler(self):
-        self.handlers = []
-        self.handlers.append(bpy.types.SpaceView3D.draw_handler_add(
+
+    def __add_handlers(self):
+        self._handlers.append(bpy.types.SpaceView3D.draw_handler_add(
             self.sync_draw_callback, (), 'WINDOW', 'PRE_VIEW'))
+        self._logger.info("Adding a draw handler")
+        self._logger.info("Handlers: " + str(self._handlers))
+
+    def remove_handlers(self):
+        self._logger.info("Removing view sync draw handlers")
+        for handler in self._handlers:
+            bpy.types.SpaceView3D.draw_handler_remove(handler, 'WINDOW')
+        self._handlers = []
 
     def has_handlers(self):
-        return len(self.handlers) > 0
+        return len(self._handlers) > 0
 
     def sync_draw_callback(self):
-        context = bpy.context
-        if not context.region_data.show_sync_view:
+        if not bpy.context.region_data.show_sync_view or not self.active_area or not self._active_window:
+            self._areas.discard(bpy.context.area)
             return
 
-        this_area = context.area
+        self._areas.add(bpy.context.area)
 
-        if this_area == self.active_area:
-            self.source_area = this_area
+        # Cleanup invalid areas
+        invalid_areas = set()
+        for area in self._areas:
+            if not area.path_resolve("height") or area not in self._active_window.screen.areas.values():
+                invalid_areas.add(area)
+        for area in invalid_areas:
+            self._areas.remove(area)
+
+        # Sync other viewports
+        if bpy.context.area == self.active_area:
             # For some reason updating another viewport causes this viewport to have an additional redraw, so we skip
-            if self.skip_sync:
-                self.skip_sync = False
+            if self._skip_sync:
+                self._skip_sync = False
                 return
-            self.skip_sync = True
+            self._skip_sync = True
 
-            #TODO: conditionally loop over all windows and screens to sync between windows.
-            #TODO: Try holding references to areas that needs drawing maybe?? Check how and when does areas change memory addresses
-            for area in context.screen.areas:
-                if area.type == "VIEW_3D" and area != this_area:
-                    if area.spaces[0].region_3d.show_sync_view:
-                        update_space(this_area.spaces[0], area.spaces[0])
+            # TODO: conditionally loop over all windows and screens to sync between windows.
+            for area in self._areas:
+                if area != bpy.context.area and area.spaces[0].region_3d.show_sync_view:
+                    update_space(bpy.context.area.spaces[0], area.spaces[0])
         return
-
-    def remove_handler(self):
-        for handler in self.handlers:
-            bpy.types.SpaceView3D.draw_handler_remove(handler, 'WINDOW')
-        self.handlers = []

--- a/sync_handler.py
+++ b/sync_handler.py
@@ -1,0 +1,74 @@
+import bpy
+
+
+def update_space(source_space, target_space):
+    def update_attributes(source, target, attributes):
+        for attribute in attributes:
+            new_attribute = getattr(source, attribute, None)
+            if new_attribute is not None:
+                setattr(target, attribute, new_attribute)
+
+    # Update space attributes, causes 2 additional redraws on target
+    space_attributes = ['clip_end', 'clip_start', 'lens']
+    update_attributes(source_space, target_space, space_attributes)
+    # Update ViewRegion3D attributes
+    # All modifiable attributes, causes 8 additional redraws on target
+    view_region_3d_attributes = ['clip_planes', 'is_orthographic_side_view', 'is_perspective', 'lock_rotation', 'show_sync_view', 'use_box_clip', 'use_clip_planes',
+                                 'view_camera_offset', 'view_camera_zoom', 'view_distance', 'view_location', 'view_perspective', 'view_rotation']
+    update_attributes(source_space.region_3d, target_space.region_3d, view_region_3d_attributes)
+
+# Issue: Our modal operator to report our mouse position is removed on loading a new file, and does not work on a new window
+
+
+class SyncDrawHandler:
+    def __init__(self):
+        self.add_handler()
+        self.source_area = None
+        self.mouse_pos = (0, 0)
+        self.skip_sync = False
+
+    # Handler order: PRE_VIEW, POST_VIEW, POST_PIXEL
+    def add_handler(self):
+        self.handlers = []
+        self.handlers.append(bpy.types.SpaceView3D.draw_handler_add(
+            self.sync_draw_callback, (), 'WINDOW', 'PRE_VIEW'))
+
+    def has_handlers(self):
+        return len(self.handlers) > 0
+
+    def update_mouse_pos(self, mouse_pos):
+        self.mouse_pos = mouse_pos
+
+    def mouse_is_in_area(self, area_window_min, area_window_max):
+        return not ((self.mouse_pos[0] < area_window_min[0]) or (self.mouse_pos[0] > area_window_max[0]) or (self.mouse_pos[1] < area_window_min[1]) or (self.mouse_pos[1] > area_window_max[1]))
+
+    def sync_draw_callback(self):
+        context = bpy.context
+        area_window_min = (context.area.x, context.area.y)
+        area_window_max = (context.area.x + context.area.width, context.area.y + context.area.height)
+        if not bpy.context.region_data.show_sync_view:
+            return
+
+        this_area = context.area
+
+        # Small optimization: Python evaluates conditions lazily, so if first conditions succeeds we don't need to do any work to check the second condition
+        if self.source_area == this_area or self.mouse_is_in_area(area_window_min, area_window_max):
+            # For some reason updating another viewport causes this viewport to have an additional redraw, so we skip
+            if self.skip_sync:
+                self.skip_sync = False
+                return
+            self.skip_sync = True
+
+            self.source_area = this_area
+            for window in context.window_manager.windows:
+                for area in window.screen.areas:
+                    if area.type == "VIEW_3D" and area != this_area:
+                        if area.spaces[0].region_3d.show_sync_view:
+                            update_space(this_area.spaces[0], area.spaces[0])
+
+        return
+
+    def remove_handler(self):
+        for handler in self.handlers:
+            bpy.types.SpaceView3D.draw_handler_remove(handler, 'WINDOW')
+        self.handlers = []

--- a/sync_handler.py
+++ b/sync_handler.py
@@ -173,6 +173,12 @@ class SyncDrawHandler:
     def sync_draw_callback(self) -> None:
         this_space = bpy.context.space_data
 
+        # Disable sync if in quadview to prevent issues
+        if len(this_space.region_quadviews) > 1:
+            if this_space.region_3d.show_sync_view:
+                this_space.region_3d.show_sync_view = False
+            return
+
         if self._preferences.pause_sync:
             return
 

--- a/sync_handler.py
+++ b/sync_handler.py
@@ -50,6 +50,8 @@ class SyncDrawHandler:
                 return
             self.skip_sync = True
 
+            #TODO: conditionally loop over all windows and screens to sync between windows.
+            #TODO: Try holding references to areas that needs drawing maybe?? Check how and when does areas change memory addresses
             for area in context.screen.areas:
                 if area.type == "VIEW_3D" and area != this_area:
                     if area.spaces[0].region_3d.show_sync_view:

--- a/ui.py
+++ b/ui.py
@@ -16,7 +16,7 @@ class SyncViewPanel(bpy.types.Panel):
     bl_category = 'View'
 
 
-class SyncView_VIEW3D_PT_setting_panel(SyncViewPanel):
+class SYNC_VIEWVIEW3D_PT_setting_panel(SyncViewPanel):
     """Settings for Sync View"""
     bl_label = "Sync View Panel"
     bl_options = {'DEFAULT_CLOSED'}
@@ -38,10 +38,10 @@ class SyncView_VIEW3D_PT_setting_panel(SyncViewPanel):
         column.prop(preferences, "sync_camera_view", icon='VIEW_CAMERA')
 
 
-class SyncView_VIEW3D_PT_sync_mode_panel(SyncViewPanel):
+class SYNC_VIEWVIEW3D_PT_sync_mode_panel(SyncViewPanel):
     """Settings for Sync View"""
     bl_label = "Sync Mode"
-    bl_parent_id = "SyncView_VIEW3D_PT_setting_panel"
+    bl_parent_id = "SYNC_VIEWVIEW3D_PT_setting_panel"
     bl_options = {'DEFAULT_CLOSED'}
 
     def draw(self, context):
@@ -52,7 +52,7 @@ class SyncView_VIEW3D_PT_sync_mode_panel(SyncViewPanel):
         box.props_enum(preferences, "sync_mode")
 
 
-ui = [SyncView_VIEW3D_PT_setting_panel, SyncView_VIEW3D_PT_sync_mode_panel]
+ui = [SYNC_VIEWVIEW3D_PT_setting_panel, SYNC_VIEWVIEW3D_PT_sync_mode_panel]
 
 
 def register():

--- a/ui.py
+++ b/ui.py
@@ -1,5 +1,4 @@
 import bpy
-from .operator_sync_view import SyncView_OT_Enable_Sync_Modal, SyncView_OT_Disable_Sync_Modal
 
 
 def menu_func(self, context):

--- a/ui.py
+++ b/ui.py
@@ -25,7 +25,9 @@ class SYNC_VIEWVIEW3D_PT_setting_panel(SyncViewPanel):
         layout = self.layout
         preferences = bpy.context.preferences.addons[__package__].preferences
         view_region = context.area.spaces[0].region_3d
-        layout.prop(view_region, "show_sync_view", text="Sync This Viewport", icon_only=True, icon="UV_SYNC_SELECT")
+        # Disable if in quadview
+        if len(context.space_data.region_quadviews) <= 1:
+            layout.prop(view_region, "show_sync_view", text="Sync This Viewport", icon_only=True, icon="UV_SYNC_SELECT")
 
         layout.label(text="Shortcuts")
         layout.operator(operator="syncview.sync_all_visible")

--- a/ui.py
+++ b/ui.py
@@ -33,9 +33,9 @@ class SyncView_VIEW3D_PT_setting_panel(SyncViewPanel):
 
         layout.label(text="Settings")
         column = layout.column()
-        column.prop(preferences, "pause_sync")
-        column.prop(preferences, "pause_sync_during_playback")
-        column.prop(preferences, "sync_camera_view")
+        column.prop(preferences, "pause_sync", icon='PAUSE')
+        column.prop(preferences, "sync_playback", icon='PLAY')
+        column.prop(preferences, "sync_camera_view", icon='VIEW_CAMERA')
 
 
 class SyncView_VIEW3D_PT_sync_mode_panel(SyncViewPanel):

--- a/ui.py
+++ b/ui.py
@@ -16,7 +16,7 @@ class SyncViewPanel(bpy.types.Panel):
     bl_category = 'View'
 
 
-class VIEW3D_PT_sync_view_setting_panel(SyncViewPanel):
+class SyncView_VIEW3D_PT_setting_panel(SyncViewPanel):
     """Settings for Sync View"""
     bl_label = "Sync View Panel"
     bl_options = {'DEFAULT_CLOSED'}
@@ -38,10 +38,10 @@ class VIEW3D_PT_sync_view_setting_panel(SyncViewPanel):
         column.prop(preferences, "sync_camera_view")
 
 
-class VIEW3D_PT_sync_view_sync_mode(SyncViewPanel):
+class SyncView_VIEW3D_PT_sync_mode_panel(SyncViewPanel):
     """Settings for Sync View"""
     bl_label = "Sync Mode"
-    bl_parent_id = "VIEW3D_PT_sync_view_setting_panel"
+    bl_parent_id = "SyncView_VIEW3D_PT_setting_panel"
     bl_options = {'DEFAULT_CLOSED'}
 
     def draw(self, context):
@@ -52,7 +52,7 @@ class VIEW3D_PT_sync_view_sync_mode(SyncViewPanel):
         box.props_enum(preferences, "sync_mode")
 
 
-ui = [VIEW3D_PT_sync_view_setting_panel, VIEW3D_PT_sync_view_sync_mode]
+ui = [SyncView_VIEW3D_PT_setting_panel, SyncView_VIEW3D_PT_sync_mode_panel]
 
 
 def register():

--- a/ui.py
+++ b/ui.py
@@ -42,6 +42,7 @@ class VIEW3D_PT_sync_view_sync_mode(SyncViewPanel):
     """Settings for Sync View"""
     bl_label = "Sync Mode"
     bl_parent_id = "VIEW3D_PT_sync_view_setting_panel"
+    bl_options = {'DEFAULT_CLOSED'}
 
     def draw(self, context):
         layout = self.layout

--- a/ui.py
+++ b/ui.py
@@ -1,7 +1,8 @@
 import bpy
+from .utils import registration
 
 
-def menu_func(self, context):
+def viewport_sync_button(self, context):
     layout = self.layout
     view_region = context.area.spaces[0].region_3d
     # Disable if in quadview
@@ -9,9 +10,55 @@ def menu_func(self, context):
         layout.prop(view_region, "show_sync_view", text="", icon_only=True, icon="UV_SYNC_SELECT")
 
 
+class SyncViewPanel(bpy.types.Panel):
+    bl_space_type = 'VIEW_3D'
+    bl_region_type = 'UI'
+    bl_category = 'View'
+
+
+class VIEW3D_PT_sync_view_setting_panel(SyncViewPanel):
+    """Settings for Sync View"""
+    bl_label = "Sync View Panel"
+    bl_options = {'DEFAULT_CLOSED'}
+
+    def draw(self, context):
+        layout = self.layout
+        preferences = bpy.context.preferences.addons[__package__].preferences
+        view_region = context.area.spaces[0].region_3d
+        layout.prop(view_region, "show_sync_view", text="Sync This Viewport", icon_only=True, icon="UV_SYNC_SELECT")
+
+        layout.label(text="Shortcuts")
+        layout.operator(operator="syncview.sync_all_visible")
+        layout.operator(operator="syncview.stop_sync_all_visible")
+
+        layout.label(text="Settings")
+        column = layout.column()
+        column.prop(preferences, "pause_sync")
+        column.prop(preferences, "pause_sync_during_playback")
+        column.prop(preferences, "sync_camera_view")
+
+
+class VIEW3D_PT_sync_view_sync_mode(SyncViewPanel):
+    """Settings for Sync View"""
+    bl_label = "Sync Mode"
+    bl_parent_id = "VIEW3D_PT_sync_view_setting_panel"
+
+    def draw(self, context):
+        layout = self.layout
+        preferences = bpy.context.preferences.addons[__package__].preferences
+
+        box = layout.box()
+        box.props_enum(preferences, "sync_mode")
+
+
+ui = [VIEW3D_PT_sync_view_setting_panel, VIEW3D_PT_sync_view_sync_mode]
+
+
 def register():
-    bpy.types.VIEW3D_HT_header.append(menu_func)
+    bpy.types.VIEW3D_HT_header.append(viewport_sync_button)
+    registration.register_classes(ui)
 
 
 def unregister():
-    bpy.types.VIEW3D_HT_header.remove(menu_func)
+    bpy.types.VIEW3D_HT_header.remove(viewport_sync_button)
+    registration.unregister_classes(ui)

--- a/ui.py
+++ b/ui.py
@@ -1,0 +1,18 @@
+import bpy
+from .operator_sync_view import SyncView_OT_Enable_Sync_Modal, SyncView_OT_Disable_Sync_Modal
+
+
+def menu_func(self, context):
+    layout = self.layout
+    view_region = context.area.spaces[0].region_3d
+    # Disable if in quadview
+    if len(context.space_data.region_quadviews) <= 1:
+        layout.prop(view_region, "show_sync_view", text="", icon_only=True, icon="UV_SYNC_SELECT")
+
+
+def register():
+    bpy.types.VIEW3D_HT_header.append(menu_func)
+
+
+def unregister():
+    bpy.types.VIEW3D_HT_header.remove(menu_func)

--- a/utils/registration.py
+++ b/utils/registration.py
@@ -1,0 +1,20 @@
+import bpy
+import os
+
+
+def register_classes(classes):
+    for cls in classes:
+        bpy.utils.register_class(cls)
+
+
+def unregister_classes(classes):
+    for cls in classes[::-1]:
+        bpy.utils.unregister_class(cls)
+
+# def register_icons(paths):
+#     global custom_icons
+#     custom_icons = bpy.utils.previews.new()
+#     icons_dir = os.path.join(os.path.dirname(__file__), "icons")
+
+#     for path in paths:
+#         custom_icons.load()

--- a/utils/registration.py
+++ b/utils/registration.py
@@ -10,11 +10,3 @@ def register_classes(classes):
 def unregister_classes(classes):
     for cls in classes[::-1]:
         bpy.utils.unregister_class(cls)
-
-# def register_icons(paths):
-#     global custom_icons
-#     custom_icons = bpy.utils.previews.new()
-#     icons_dir = os.path.join(os.path.dirname(__file__), "icons")
-
-#     for path in paths:
-#         custom_icons.load()


### PR DESCRIPTION
Sync View Version 1.0.0:
* Can selectively sync viewports together
    * Only the view is synced, everything else can be configured independently as usual
        * i.e. two viewports can be sync where one displays wireframe while the other displays material preview
* Thee sync modes for viewports with sync enabled:
    * Sync all viewports in the same window
    * Sync all viewports in the same workspace (works across windows)
    * Sync all viewports in the blend file
* Performance Toggles:
    * Pause sync on all viewports
    * Pause sync during playback
    * Don't sync viewports in camera view

Known Minor Issue:
If a viewport is syncing and it enters quad view, all quad view settings will be set to false. 